### PR TITLE
fix(docs): text clarifications for wallet UI

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -28,14 +28,12 @@ export default function Home() {
 
   return (
     <div className="flex flex-col gap-8 p-4 justify-center">
-      <h3 className="text-2xl font-bold">You don&apos;t have any account yet...</h3>
+      <h3 className="text-2xl font-bold">No accounts</h3>
 
       <div className="flex flex-col items-center justify-between gap-3">
-        <Button onClick={handleGenerate}>Generate new wallet</Button>
+        <Button onClick={handleGenerate}>Generate account</Button>
 
-        <span className="text-xl font-semibold">- or -</span>
-
-        <Button onClick={() => navigate("import-wallet")}>Import existing wallet</Button>
+        <Button onClick={() => navigate("import-wallet")}>Import existing account</Button>
       </div>
     </div>
   );

--- a/src/pages/ImportWallet.tsx
+++ b/src/pages/ImportWallet.tsx
@@ -27,7 +27,7 @@ export default function ImportWallet() {
     <div className="flex w-full flex-col gap-4 p-4">
       <ArrowLeft onClick={() => navigate(-1)} className="cursor-pointer" />
 
-      <h3 className="text-2xl font-bold">Provide details of the imported wallet</h3>
+      <h3 className="text-2xl font-bold">Import account</h3>
 
       <ImportWalletForm onSubmit={onImportWalletSubmit} />
     </div>

--- a/src/pages/Wallet.tsx
+++ b/src/pages/Wallet.tsx
@@ -26,7 +26,7 @@ export default function Wallet() {
 
   return (
     <div className="flex w-full flex-col gap-4 p-4">
-      <h3 className="text-2xl font-bold">Your current wallet details</h3>
+      <h3 className="text-2xl font-bold">Current account</h3>
 
       <div className="flex w-full flex-col gap-2">
         <Label className="font-bold">Address</Label>
@@ -34,13 +34,13 @@ export default function Wallet() {
       </div>
 
       <div className="flex w-full flex-col gap-2">
-        <Label className="font-bold">Public Key</Label>
+        <Label className="font-bold">Public key</Label>
         {account?.[StorageKeys.PUBLIC_KEY]}
       </div>
 
       <div className="flex w-full flex-col gap-2">
         <div className="flex flex-wrap gap-2 align-middle">
-          <Label className="font-bold">Private Key</Label>
+          <Label className="font-bold">Private key</Label>
 
           <div className="cursor-pointer" onClick={() => setPrivateKeyVisible(!privateKeyVisible)}>
             {privateKeyVisible ? <EyeOff size={20} /> : <Eye size={20} />}
@@ -96,7 +96,7 @@ function OperationSigningDialog({
 
   return (
     <div className="flex flex-col gap-4">
-      <h1 className="text-lg">Do you want to sign operation with current wallet?</h1>
+      <h1 className="text-lg">Do you want to sign the operation with the current address?</h1>
 
       <div className="flex w-full justify-end gap-4">
         <Button variant="outline" onClick={handleReject}>


### PR DESCRIPTION
I know that this wallet is just in development mode but I had a few suggestions for the text. 
<img width="401" alt="Screenshot 2025-04-07 at 11 42 10 AM" src="https://github.com/user-attachments/assets/92f212e1-58bd-4456-928c-b5ab7b3b76fa" />
<img width="403" alt="Screenshot 2025-04-07 at 11 42 16 AM" src="https://github.com/user-attachments/assets/be339e2d-31f8-4f76-8bef-86a7f6c989ed" />
<img width="446" alt="Screenshot 2025-04-07 at 11 43 20 AM" src="https://github.com/user-attachments/assets/4bff1c70-3f09-4a3a-98f0-f3f75cf50b5a" />
