### PR TITLE
fix(docs): install submodules in readme build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,19 @@ Follow these steps to build the extension and install it in Google Chrome:
    cd dev-wallet
    ```
 
-2. Install dependencies:
+2. Clone the required submodules:
+
+   ```sh
+   git submodule update --init
+   ```
+
+3. Install dependencies:
 
    ```sh
    pnpm i
    ```
 
-3. Build the extension:
+4. Build the extension:
 
    ```sh
    pnpm build


### PR DESCRIPTION
To get the install steps to work I had to install git submodules, or else `pnpm i` threw this error:

<img width="441" height="116" alt="Screenshot 2025-08-14 at 8 14 55 AM" src="https://github.com/user-attachments/assets/89ca5c91-e962-4f49-8935-44e0b314b54e" />
